### PR TITLE
Add how-to on kube-token-refresher

### DIFF
--- a/docs/modules/ROOT/pages/how-tos/crossplane_service_broker/connect_service_catalog_to_service_broker.adoc
+++ b/docs/modules/ROOT/pages/how-tos/crossplane_service_broker/connect_service_catalog_to_service_broker.adoc
@@ -57,17 +57,9 @@ NOTE: Don't forget to change the values `client_id`, `client_secret` and the URL
 The token that's issued by the authentication server may only be valid for a short time.
 (The token which was shown before in the xref:app-catalog:ROOT:how-tos/crossplane_service_broker/bearer_token_authentication.adoc#get_a_bearer_token[HTTP _Bearer Token_ authentication] section was only valid for 600 seconds, that's just 10 minutes.)
 
-We're currently working on a way to automatically refresh the token before it expires.
-If you don't strictly need _Bearer Token_ authentication (which is when you don't have multiple clients, such as multiple teams), then you can also fall back to _Basic_ authentication, which is explained at the bottom.
-
-But until then:
-Once the token expires, you need to deregister the broker, update the token (see above), and then re-register it (see further below on how to do that).
-
-The command to deregister the _Crossplane Service Broker_ is as follows:
-
-```bash
-svcat deregister servicebroker-test
-```
+In that case you will need to deploy a https://github.com/vshn/kube-token-refresher[kube-token-refresher].
+The xref:app-catalog:ROOT:how-tos/crossplane_service_broker/kube_token_refresher.adoc[Setup Kube Token Refresher] how-to covers the setup.
+In this case you won't need to manually fetch a _Bearer Token_.
 ====
 
 == Register the _Crossplane Service Broker_ at the _Service Catalog_

--- a/docs/modules/ROOT/pages/how-tos/crossplane_service_broker/connect_service_catalog_to_service_broker.adoc
+++ b/docs/modules/ROOT/pages/how-tos/crossplane_service_broker/connect_service_catalog_to_service_broker.adoc
@@ -59,7 +59,7 @@ The token that's issued by the authentication server may only be valid for a sho
 
 In that case you will need to deploy a https://github.com/vshn/kube-token-refresher[kube-token-refresher].
 The xref:app-catalog:ROOT:how-tos/crossplane_service_broker/kube_token_refresher.adoc[Setup Kube Token Refresher] how-to covers the setup.
-In this case you won't need to manually fetch a _Bearer Token_.
+The token refresher will ensure that the service catalog always has a valid _Bearer Token_.
 ====
 
 == Register the _Crossplane Service Broker_ at the _Service Catalog_

--- a/docs/modules/ROOT/pages/how-tos/crossplane_service_broker/kube_token_refresher.adoc
+++ b/docs/modules/ROOT/pages/how-tos/crossplane_service_broker/kube_token_refresher.adoc
@@ -8,13 +8,15 @@ You will need access to an OIDC provider, valid credentials to request a _Bearer
 [NOTE]
 ====
 The Kube Token Refresher only manages a single secret.
-If you need multiple brokers with different short lived bearer tokens, you will need to deploy it multiple times.
+If you need multiple brokers with different short lived bearer tokens, you will need to deploy the token refresher multiple times.
 ====
 
 == Kubernetes RBAC
 
 To allow the  Kube Token Refresher to manage the secret, we need to create a Service Account and a corresponding Role.
-Apply the following to the same namespace the Kube Token Refresher will be deployed to.
+Apply the following in the same namespace the Kube Token Refresher will be deployed to.
+
+NOTE: With this RBAC configuration the token refresher must run in the namespace of the secret which it refreshes.
 
 [source,yaml]
 ----
@@ -153,7 +155,6 @@ Expect some delays and request a new token early enough.
 * `KTR_OIDC_TOKENURL`: The URL to fetch the token from. 
 See xref:app-catalog:ROOT:how-tos/crossplane_service_broker/crossplane_service_broker/bearer_token_authentication.html[Bearer Token authentication] for more details on what this is.
 * `KTR_OIDC_CLIENTID` and `KTR_OIDC_CLIENTSECRET`: The credentials we created earlier.
-
 
 
 

--- a/docs/modules/ROOT/pages/how-tos/crossplane_service_broker/kube_token_refresher.adoc
+++ b/docs/modules/ROOT/pages/how-tos/crossplane_service_broker/kube_token_refresher.adoc
@@ -1,0 +1,159 @@
+= Install Kube Token Refresher
+
+As discussed in xref:app-catalog:ROOT:how-tos/crossplane_service_broker/crossplane_service_broker/connect_service_catalog_to_service_broker.html[Connecting the Service Catalog to a Service Broker], issued tokens might only be valid for a short period of time.
+For this purpose we developed the https://github.com/vshn/kube-token-refresher[kube-token-refresher], which periodically fetches a new bearer token and writes it to a secret for the Service Catalog.
+
+You will need access to an OIDC provider, valid credentials to request a _Bearer Token_, and permission to get, update, and create secrets.
+
+[NOTE]
+====
+The Kube Token Refresher only manages a single secret.
+If you need multiple brokers with different short lived bearer tokens, you will need to deploy it multiple times.
+====
+
+== Kubernetes RBAC
+
+To allow the  Kube Token Refresher to manage the secret, we need to create a Service Account and a corresponding Role.
+Apply the following to the same namespace the Kube Token Refresher will be deployed to.
+
+[source,yaml]
+----
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: kube-token-refresher
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: kube-token-refresher
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: kube-token-refresher
+subjects:
+- kind: ServiceAccount
+  name: kube-token-refresher
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: kube-token-refresher
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - get
+  - update
+
+----
+
+
+== OIDC Credentials
+
+Next you will need to get a `client_id` and `client_secret` to request a `access_token`.
+Create these on your authentication server or contact authorized personnel.
+
+Then write them to a secret in the namespace the Kube Token Refresher will be deployed.
+
+[source,yaml]
+----
+---
+apiVersion: v1
+stringData:
+  id: <client_id>
+  secret: <client_secret>
+kind: Secret
+metadata:
+  name: kube-token-refresher
+type: Opaque
+
+----
+
+
+== Standalone Deployment
+
+Finally we will deploy the Token Refresher. 
+In this section we will deploy it as a standalone deployment.
+
+Apply the following:
+
+[source,yaml]
+----
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: kube-token-refresher
+  name: token-refresher
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: token-refresher
+  template:
+    metadata:
+      labels:
+        app: token-refresher
+    spec:
+      containers:
+      - name: refresher
+        env:
+        - name: KTR_SECRET_NAME
+          value: "bearer-creds"
+        - name: KTR_SECRET_NAMESPACE
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: metadata.namespace
+        - name: KTR_INTERVAL
+          value: 500
+        - name: KTR_OIDC_TOKENURL
+          value: <token-url>
+        - name: KTR_OIDC_CLIENTID
+          valueFrom:
+            secretKeyRef:
+              name: kube-token-refresher
+              key: id
+        - name: KTR_OIDC_CLIENTSECRET
+          valueFrom:
+            secretKeyRef:
+              name: kube-token-refresher
+              key: secret
+        image: quay.io/vshn/kube-token-refresher:latest
+        imagePullPolicy: Always
+        resources:
+          limits:
+            cpu: 100m
+            memory: 30Mi
+          requests:
+            cpu: 100m
+            memory: 10Mi
+      dnsPolicy: ClusterFirst
+      restartPolicy: Always
+      serviceAccountName: kube-token-refresher
+
+----
+
+There are a few things that can be configured.
+
+* `KTR_SECRET_NAME`: The name of the secret that will be updated. 
+This is the same secret referenced as a `bearer-secret` when xref:app-catalog:ROOT:how-tos/crossplane_service_broker/crossplane_service_broker/connect_service_catalog_to_service_broker.html#_register_the_crossplane_service_broker_at_the_service_catalog[registering the service catalog]
+* `KTR_SECRET_NAMESPACE`: The namespace this secrets is in.
+This example assumes it to be in the same namespace as the deployment.
+* `KTR_INTERVAL`: In what interval (in seconds) to fetch a new token. 
+This depends on your authentication server.
+Expect some delays and request a new token early enough.
+* `KTR_OIDC_TOKENURL`: The URL to fetch the token from. 
+See xref:app-catalog:ROOT:how-tos/crossplane_service_broker/crossplane_service_broker/bearer_token_authentication.html[Bearer Token authentication] for more details on what this is.
+* `KTR_OIDC_CLIENTID` and `KTR_OIDC_CLIENTSECRET`: The credentials we created earlier.
+
+
+
+

--- a/docs/modules/ROOT/partials/nav-howtos.adoc
+++ b/docs/modules/ROOT/partials/nav-howtos.adoc
@@ -7,6 +7,7 @@
 ** xref:app-catalog:ROOT:how-tos/crossplane_service_broker/setup_service_catalog.adoc[Setup a _Service Catalog_]
 ** xref:app-catalog:ROOT:how-tos/crossplane_service_broker/bearer_token_authentication.adoc[HTTP _Bearer Token_ authentication]
 ** xref:app-catalog:ROOT:how-tos/crossplane_service_broker/connect_service_catalog_to_service_broker.adoc[Connect the _Service Catalog_ to the _Service Broker_]
+** xref:app-catalog:ROOT:how-tos/crossplane_service_broker/kube_token_refresher.adoc[Setup Kube Token Refresher]
 ** xref:app-catalog:ROOT:how-tos/crossplane_service_broker/basic_authentication.adoc[HTTP _Basic_ authentication]
 ** xref:app-catalog:ROOT:how-tos/crossplane/implement_new_service_offering.adoc[Implement a New Service]
 


### PR DESCRIPTION
Adds instructions on how to setup the kube-token-refresher. Deploys KTR as a deployment instead of as a sidecar of the Application Catalog, because the Application Catalog helm chart does not seem to have a way to add sidecars.