### PR TITLE
Fixed typo in logging nav name

### DIFF
--- a/docs/modules/ROOT/partials/nav.adoc
+++ b/docs/modules/ROOT/partials/nav.adoc
@@ -35,7 +35,7 @@
 *** xref:app-catalog:ROOT:explanations/decisions/capacity-alerting.adoc[Capacity Alerting]
 ** xref:app-catalog:ROOT:explanations/decisions/redis.adoc[Redis by VSHN]
 ** xref:app-catalog:ROOT:explanations/decisions/mariadb.adoc[MariaDB by VSHN]
-** xref:app-catalog:ROOT:explanations/decisions/logging.adoc []
+** xref:app-catalog:ROOT:explanations/decisions/logging.adoc[]
 ** xref:app-catalog:ROOT:explanations/decisions/crossplane.adoc[Crossplane as Control Plane]
 ** xref:app-catalog:ROOT:explanations/decisions/composition-deployments.adoc[Composition Deployments]
 ** xref:app-catalog:ROOT:explanations/decisions/api-design.adoc[API Design]


### PR DESCRIPTION
There was a typo in logging navigation item name, which corrupted the item display.

## Summary


## Checklist

- [x] Try to isolate changes into separate PRs (to build a better changelog).
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `change`, `decision`, `requirement/quality`, `requirement/functional`, `dependency`
      as they show up in the changelog
- [x] Link this PR to related issues if applicable.

<!--
NOTE:
- Remove items that do not apply.
- These things are not required to open a PR and can be done afterwards, while the PR is open.
-->
