### PR TITLE
Split backup and restore into separate maturity levels

### DIFF
--- a/docs/modules/ROOT/pages/reference/service-maturity.adoc
+++ b/docs/modules/ROOT/pages/reference/service-maturity.adoc
@@ -31,18 +31,23 @@ See also:
 * xref:reference/quality-requirements/usability/api-validation.adoc[Service Instance API Validation]
 * xref:reference/quality-requirements/usability/provisioning-time.adoc[Provisioning Time]
 
-== Iteration: Backup and Restore
+== Iteration: Backup
 
 As a user of the service I can:
 
 * enable Backup on a service instance
 * disable Backup on a service instance
-* manually restore data for a service instance
 
 See also:
 
 * xref:reference/quality-requirements/portability/backup-exports.adoc[Backups Can Be Exported]
 * xref:reference/quality-requirements/reliability/backup-interval.adoc[Minimum Backup Interval]
+
+== Iteration: Restore
+
+As a user of the service I can:
+
+* manually restore data for a service instance
 
 == Iteration: Logs
 

--- a/docs/modules/ROOT/pages/reference/service-maturity.adoc
+++ b/docs/modules/ROOT/pages/reference/service-maturity.adoc
@@ -37,6 +37,7 @@ As a user of the service I can:
 
 * enable Backup on a service instance
 * disable Backup on a service instance
+* request a restore for a service instance
 
 See also:
 


### PR DESCRIPTION
Backup and restore were together in one maturity level. Often they are not implemented together.

## Summary


## Checklist

- [x] Try to isolate changes into separate PRs (to build a better changelog).
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `change`, `decision`, `requirement/quality`, `requirement/functional`, `dependency`
      as they show up in the changelog
- [x] Link this PR to related issues if applicable.

<!--
NOTE:
- Remove items that do not apply.
- These things are not required to open a PR and can be done afterwards, while the PR is open.
-->
