### PR TITLE
Add playbook to restore Redis Backman backup

### DIFF
--- a/docs/modules/ROOT/pages/csp/spks/runbooks/redis/RedisRestoreBackman.adoc
+++ b/docs/modules/ROOT/pages/csp/spks/runbooks/redis/RedisRestoreBackman.adoc
@@ -1,0 +1,79 @@
+= Restore Backman Backup
+
+
+== icon:glasses[] Overview
+
+Backman can backup Redis, but it can't automatically restore the backups.
+So the restore is a manual process.
+
+== icon:bug[] Steps for Restoring
+
+=== Get Access to the bucket
+
+Backman saves the backups in S3 object storage.
+The first step is to get access to the bucket where the backups reside.
+This is provided by the user, as we don't have access to their backman configuration.
+
+=== Restore dump
+
+[source,bash]
+----
+INSTANCE=<instance_id>
+kubectl -n $INSTANCE scale sts redis-node --replicas=0
+
+kubectl apply -f - <<EOF
+apiVersion: v1
+kind: Pod
+metadata:
+  name: minio-client
+  namespace: $INSTANCE
+spec:
+  containers:
+  - command:
+    - bash
+    - -ec
+    - sleep 36000
+    image: remote-docker.artifactory.swisscom.com/bitnami/minio-client:latest
+    imagePullPolicy: IfNotPresent
+    name: mc
+    resources:
+      limits:
+        cpu: "1"
+        memory: 2560Mi
+      requests:
+        cpu: 100m
+        memory: 100Mi
+    volumeMounts:
+    - mountPath: /restore
+      name: data-0
+  dnsPolicy: ClusterFirst
+  restartPolicy: Never
+  serviceAccount: default
+  serviceAccountName: default
+  terminationGracePeriodSeconds: 30
+  volumes:
+  - name: data-0
+    persistentVolumeClaim:
+      claimName: redis-data-redis-node-0
+EOF
+----
+
+Then use the minio client to connect to the bucket and restore:
+
+[source,bash]
+----
+kubectl -n $INSTANCE exec -it minio-client -- bash
+mc alias set bucket $endpoint $accesskey $secretkey
+# check the specific path in the bucket
+mc ls bucket/...
+mc cp bucket/.../dump.gzip /restore
+cd /restore
+gunzip dump.gzip
+----
+
+Delete the minio client pod and scale up the Redis instance:
+[source,bash]
+----
+kubectl -n $INSTANCE delete pod minio-client
+kubectl -n $INSTANCE scale sts redis-node --replicas=3
+----

--- a/docs/modules/ROOT/partials/nav.adoc
+++ b/docs/modules/ROOT/partials/nav.adoc
@@ -52,6 +52,7 @@
 **** xref:csp/spks/runbooks/redis/RedisOutOfMemory.adoc[]
 **** xref:csp/spks/runbooks/redis/RedisReplicationBroken.adoc[]
 **** xref:csp/spks/runbooks/redis/RedisTooManyMasters.adoc[]
+**** xref:csp/spks/runbooks/redis/RedisRestoreBackman.adoc[]
 ** xref:csp/spks/mariadb_galera.adoc[]
 *** xref:csp/spks/mariadb_galera_lb_with_haproxy.adoc[]
 *** xref:csp/spks/mariadb_haproxy_stats.adoc[]


### PR DESCRIPTION


## Summary
Backup can't restore Redis by itself, so the restore has to be done manually.

## Checklist

- [x] Try to isolate changes into separate PRs (to build a better changelog).
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `change`, `decision`, `requirement/quality`, `requirement/functional`, `dependency`
      as they show up in the changelog
- [ ] Link this PR to related issues if applicable.

<!--
NOTE:
- Remove items that do not apply.
- These things are not required to open a PR and can be done afterwards, while the PR is open.
-->
