### PR TITLE
Fix variable interpolation in mariadb runbook

### DIFF
--- a/docs/modules/ROOT/pages/csp/spks/runbooks/mariadb_galera/MySQLGaleraClusterDown.adoc
+++ b/docs/modules/ROOT/pages/csp/spks/runbooks/mariadb_galera/MySQLGaleraClusterDown.adoc
@@ -26,13 +26,14 @@ apiVersion: v1
 kind: Pod
 metadata:
   name: mariadb-debug-pod
-  namespace: $INSTANCE
+  namespace: ${INSTANCE}
 spec:
   containers:
   - command:
     - bash
     - -ec
     - |
+$(cat <<'SCRIPT'
       for i in 0 1 2; do
         if [[ "$(cat /bitnami/mariadb-$i/data/grastate.dat 2>/dev/null | grep safe_to_bootstrap)" == "safe_to_bootstrap: 1" ]]; then
           echo "It's safe to bootstrap from pod mariadb-$i";
@@ -59,10 +60,12 @@ spec:
       done
       if [[ $diff_uid ]]; then
         echo "UID different across instances, please check manually (see individual output above)"
-        echo "Most likely pod to boostrap from is mariadb-$instance"
+        echo "Most likely pod to bootstrap from is mariadb-$instance"
         exit
       fi
       echo "It's safe to bootstrap from pod mariadb-$instance"
+SCRIPT
+)
     image: remote-docker.artifactory.swisscom.com/bitnami/mariadb-galera:10.5.21-debian-11-r10
     imagePullPolicy: IfNotPresent
     name: mariadb-galera


### PR DESCRIPTION
## Summary

This PR fixes the wrong interpolation of variables in the runbook script. The variables should not be interpolated locally but on the pod.

## Checklist

- [x] Try to isolate changes into separate PRs (to build a better changelog).
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `change`, `decision`, `requirement/quality`, `requirement/functional`, `dependency`
      as they show up in the changelog
- [ ] Link this PR to related issues if applicable.

<!--
NOTE:
- Remove items that do not apply.
- These things are not required to open a PR and can be done afterwards, while the PR is open.
-->
