### PR TITLE
Add runbook for failed maintenance jobs

### DIFF
--- a/docs/modules/ROOT/pages/framework/runbooks/AppCatMaintenanceJobFailed.adoc
+++ b/docs/modules/ROOT/pages/framework/runbooks/AppCatMaintenanceJobFailed.adoc
@@ -1,0 +1,45 @@
+= Alert rule: AppCatMaintenanceJobFailed
+:page-aliases: how-tos/appcat/AppCatMaintenanceJobFailed.adoc
+
+== icon:glasses[] Overview
+
+This alert triggers if the maintenance job failed for any given AppCat service.
+
+== icon:bug[] Steps for Debugging
+
+All AppCat maintenance runs as a Kubernetes Job (scheduled via CronJob).
+To figure out what went wrong, connect to the K8s cluster and look at the logs of the failed job.
+
+=== Find the failed job
+
+For most services, the maintenance CronJob lives in the control namespace:
+
+[source,bash]
+----
+kubectl -n $controlNamespace get jobs
+kubectl -n $controlNamespace logs job/$failedJobName
+----
+
+Operator-based services like PostgreSQL have their maintenance in the instance namsepace:
+
+[source,bash]
+----
+kubectl -n $instanceNamespace get jobs
+kubectl -n $instanceNamespace logs job/$failedJobName
+----
+
+If the job pod is gone, describe the CronJob to see recent execution history:
+
+[source,bash]
+----
+kubectl -n $instanceNamespace describe cronjob/maintenancejob
+----
+
+=== Most probable causes
+
+* *Pre-maintenance backup failed*: Maintenance always attempts a backup first.
+If the backup fails, the entire maintenance job is aborted.
+* *Image registry unreachable*: Helm-based services query a Docker registry to find the latest version.
+A registry outage or rate limit will cause the job to fail.
+* *Upstream service unresponsive*: For PostgreSQL (StackGres), the maintenance job communicates with the StackGres API.
+If the StackGres operator is unhealthy, the job will time out (default: 1 hour).

--- a/docs/modules/ROOT/pages/framework/runbooks/AppCatMaintenanceJobFailed.adoc
+++ b/docs/modules/ROOT/pages/framework/runbooks/AppCatMaintenanceJobFailed.adoc
@@ -20,7 +20,7 @@ kubectl -n $controlNamespace get jobs
 kubectl -n $controlNamespace logs job/$failedJobName
 ----
 
-Operator-based services like PostgreSQL have their maintenance in the instance namsepace:
+Operator-based services like PostgreSQL have their maintenance in the instance namespace:
 
 [source,bash]
 ----

--- a/docs/modules/ROOT/partials/nav.adoc
+++ b/docs/modules/ROOT/partials/nav.adoc
@@ -124,6 +124,7 @@
 ** Runbooks
 *** xref:framework/runbooks/AppCatRelease.adoc[]
 *** xref:framework/runbooks/AppCatBackupJobError.adoc[]
+*** xref:framework/runbooks/AppCatMaintenanceJobFailed.adoc[]
 *** xref:framework/runbooks/AppCatRollback.adoc[]
 *** xref:framework/runbooks/AppCatRedis.adoc[]
 *** xref:framework/runbooks/GuaranteedUptimeTarget.adoc[]


### PR DESCRIPTION
## Summary

This adds a runbook for the failed maintenance alerts implemented in https://github.com/vshn/component-appcat/pull/1082 

## Checklist

- [x] Try to isolate changes into separate PRs (to build a better changelog).
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `change`, `decision`, `requirement/quality`, `requirement/functional`, `dependency`
      as they show up in the changelog
- [x] Link this PR to related issues if applicable.