### PR TITLE
Adjust Forgejo runner ADR and reject it due to security concerns

### DIFF
--- a/docs/modules/ROOT/pages/adr/0054-vshn-managed-forgejo-runners.adoc
+++ b/docs/modules/ROOT/pages/adr/0054-vshn-managed-forgejo-runners.adoc
@@ -3,8 +3,8 @@
 :adr_owner:     Schedar
 :adr_reviewers: Schedar
 :adr_date:      2026-05-20
-:adr_upd_date:  2026-06-02
-:adr_status:    draft
+:adr_upd_date:  2026-06-23
+:adr_status:    rejected
 :adr_tags:      forgejo,ci,code-hosting
 
 include::partial$adr-meta.adoc[]
@@ -16,6 +16,13 @@ We offer per-instance Forgejo Actions runners as an optional, separately billed 
 Each runner is deployed in the Forgejo instance namespace for simplicity.
 Registration uses `provider-http` to call the Forgejo API directly.
 The resulting credential is written as a Kubernetes Secret, which the `forgejo-runner` Helm chart consumes.
+====
+
+[WARNING]
+.Rejected — implementation paused due to shared-cluster security concerns
+====
+Work on this feature was started (see https://github.com/vshn/appcat/pull/684[appcat#684]) but paused after a security review identified that running privileged pods on a shared cluster cannot be made safe without additional infrastructure changes.
+The design is sound and may be revisited; the required prerequisites are documented in the <<path-forward>> section.
 ====
 
 == Context
@@ -295,6 +302,33 @@ Job containers connect to that daemon instead of the host daemon.
 * Concurrent jobs share the same daemon; they can see each other's containers and left-over artifacts.
 * Resource constraints on the runner pod have no effect on containers spawned inside the DinD daemon.
 
+[IMPORTANT]
+.DinD does not provide a hard security boundary for job containers
+====
+Forgejo's docs note that setting `container.privileged = false` on the job container reduces the attack surface.
+This is not a hard security guarantee.
+
+The runner pod itself runs with `privileged: true`.
+The nested `dockerd` (DinD sidecar) runs *inside* that privileged pod, so all containers it spawns operate within the blast radius of that privileged pod.
+
+Additionally, if a job container can reach the DinD socket (`/var/run/docker.sock` of the nested daemon), it can spawn a new container with elevated privileges:
+
+[source,shell]
+----
+docker run --privileged -v /:/host alpine chroot /host
+----
+
+This means:
+
+* A compromised job can access the host filesystem, load kernel modules, and read other pods' secrets from `/proc`.
+* On a shared node, all other tenants co-scheduled there are reachable.
+* There is no hypervisor boundary — all containers share the host kernel, so kernel exploits are not contained.
+
+The only true isolation boundary is the privileged runner pod itself.
+Anything running inside it — including unprivileged job containers — is within the blast radius of a node compromise.
+This makes DinD on a shared cluster an unacceptable risk without additional VM-level isolation.
+====
+
 ==== Option B: Rootless Docker / Podman
 
 Job containers run via a rootless Docker or Podman daemon inside the runner pod.
@@ -348,6 +382,56 @@ It deploys into the Forgejo instance namespace, matching the placement decided h
 `provider-http` registers the runner against the Forgejo admin API, the composition reads the returned token and writes it into a `.runner` config secret, and the `forgejo-runner` Helm chart consumes that secret.
 
 What remains is to expose runner enablement and sizing on the claim instead of always provisioning one, and, on Servala, to wire up the gVisor `RuntimeClass` for the job containers.
+
+== Rejection rationale
+
+During implementation (https://github.com/vshn/appcat/pull/684[appcat#684]) a security review identified that the design cannot be made safe on a shared cluster without infrastructure prerequisites that were not in place.
+
+The core problem is that any runner topology that requires a privileged pod — including DinD — places an unacceptable trust boundary on a shared cluster:
+
+* A privileged pod has full access to the node: host filesystem, other pods' secrets via `/proc`, network traffic on the node, and the ability to load kernel modules.
+* The DinD sidecar does not isolate job containers from this blast radius (see the DinD security note above).
+* Not setting `container.privileged = false` on job containers reduces accidental exposure but is not a hard boundary.
+* Rootless Docker/Podman (Option B) removes the privileged pod requirement and is the correct executor choice, but alone it does not contain a determined attacker exploiting a kernel vulnerability, since all containers still share the host kernel.
+* Without VM-level isolation (gVisor, Kata Containers, or a dedicated cluster), the shared kernel is an unresolved gap.
+
+The feature is therefore paused rather than proceeding with an unresolved security gap.
+
+[#path-forward]
+== Path forward
+
+The following options, in increasing order of effort and isolation strength, would unblock the feature:
+
+[cols="1,2,1,1", options="header"]
+|===
+| Option | Description | Effort | Isolation strength
+
+| Dedicated tainted node pool
+| Taint a pool of nodes exclusively for runner pods so no other tenant workloads are co-scheduled.
+  Limits the blast radius of a node escape to runner nodes only.
+  Necessary baseline for any option, but not sufficient alone.
+| Low
+| Partial
+
+| gVisor `RuntimeClass` on runner nodes
+| Deploy gVisor on the runner node pool and assign a `RuntimeClass` to runner pods.
+  gVisor intercepts syscalls with a user-space kernel, containing kernel exploits inside the sandbox.
+| Medium
+| Strong (syscall sandbox)
+
+| Kata Containers on runner nodes
+| Replace the container runtime on runner nodes with Kata Containers (QEMU/Cloud Hypervisor/Firecracker).
+  Each pod runs in a lightweight VM; container escapes do not reach the host kernel.
+  Stronger than gVisor; higher overhead and more operational complexity.
+| High
+| Very strong (VM boundary)
+
+| Separate CI cluster
+| Run a dedicated Kubernetes cluster exclusively for CI workloads, not shared with customer data or production services.
+  Privileged pods are acceptable because the blast radius is contained to the CI cluster.
+| High
+| Strong (cluster boundary)
+|===
 
 == Consequences
 


### PR DESCRIPTION
## Summary

Due to security concerns when using the runners on shared infrastructure (e.g. Servala) we reject this ADR for now and need to invest more time to investigate potential solutions that provide adequate security.

## Checklist

- [ ] Try to isolate changes into separate PRs (to build a better changelog).
- [ ] Categorize the PR by setting a good title and adding one of the labels:
      `change`, `decision`, `requirement/quality`, `requirement/functional`, `dependency`
      as they show up in the changelog
- [ ] Link this PR to related issues if applicable.

<!--
NOTE:
- Remove items that do not apply.
- These things are not required to open a PR and can be done afterwards, while the PR is open.
-->
